### PR TITLE
Add PIL to install instructions requirements

### DIFF
--- a/install.md
+++ b/install.md
@@ -21,6 +21,7 @@ conda install cython
 conda install matplotlib
 conda install shapely
 conda install fiona
+conda install PIL
 pip install pyproj
 pip install descartes
 pip install rasterio


### PR DESCRIPTION
Part 1 plotting will fail without PIL in the virtualenv. Conda works around pip difficulties with PIL.
